### PR TITLE
Container reg sa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 overlays/tom-gke/*.env
+overlays/tom-gke/gcp-sa.json
 build/*

--- a/overlays/tom-gke/gcp-sa.json.shadow
+++ b/overlays/tom-gke/gcp-sa.json.shadow
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": ""
+}

--- a/overlays/tom-gke/kustomization.yaml
+++ b/overlays/tom-gke/kustomization.yaml
@@ -23,6 +23,9 @@ configMapGenerator:
       - jcasc-default-config.yaml=jcasc.yaml
 
 secretGenerator:
-- name: tom-jenkins-auth
-  envs: 
-  - jenkins-auth.env
+  - name: tom-jenkins-auth
+    envs:
+    - jenkins-auth.env
+  - name: gcp-sa
+    files:
+      - gcp-sa.json=gcp-sa.json

--- a/overlays/tom-gke/kustomization.yaml
+++ b/overlays/tom-gke/kustomization.yaml
@@ -28,4 +28,6 @@ secretGenerator:
     - jenkins-auth.env
   - name: gcp-sa
     files:
-      - gcp-sa.json=gcp-sa.json
+    - gcp-sa.json=gcp-sa.json
+    options:
+      disableNameSuffixHash: true


### PR DESCRIPTION
This is how we can use a GCP service account (_not_ RBAC) to access GCP resources that are outside GKE, like container registry. Mount the gke-gcp-sa secret into your job's Pod if you want to use it.