### PR TITLE
Add service account for deleting pods

### DIFF
--- a/overlays/tom-gke/kubectl-service-account.yaml
+++ b/overlays/tom-gke/kubectl-service-account.yaml
@@ -2,23 +2,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubectl-sa
-  namespace: thomasflanigan
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: kubectl-sa
-  namespace: thomasflanigan
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch", "patch", "delete"]
+    verbs: ["delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: kubectl-sa
-  namespace: thomasflanigan
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -26,4 +23,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubectl-sa
-    namespace: services

--- a/overlays/tom-gke/kubectl-service-account.yaml
+++ b/overlays/tom-gke/kubectl-service-account.yaml
@@ -10,7 +10,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["delete"]
+    verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/overlays/tom-gke/kubectl-service-account.yaml
+++ b/overlays/tom-gke/kubectl-service-account.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubectl-sa
+  namespace: thomasflanigan
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubectl-sa
+  namespace: thomasflanigan
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -16,6 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kubectl-sa
+  namespace: thomasflanigan
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -23,4 +26,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubectl-sa
-    namespace: kubectl-sa
+    namespace: services

--- a/overlays/tom-gke/kubectl-service-account.yaml
+++ b/overlays/tom-gke/kubectl-service-account.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubectl-sa
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubectl-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubectl-sa
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-sa
+    namespace: kubectl-sa

--- a/overlays/tom-gke/kubectl-service-account.yaml
+++ b/overlays/tom-gke/kubectl-service-account.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kubectl-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: kubectl-sa
 subjects:
   - kind: ServiceAccount

--- a/overlays/tom-gke/kustomization.yaml
+++ b/overlays/tom-gke/kustomization.yaml
@@ -3,6 +3,7 @@ namespace: services
 resources:
   - ../../helm-base
   - agent-service-account.yaml
+  - kubectl-service-account.yaml
 
 patches:
 - target:


### PR DESCRIPTION
This is needed auth for certain job stages like when we need to deploy a fresh darnbot for example.